### PR TITLE
provide ssl configuration, include x-forwarding for ws

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Ports
 HTTP_PORT=9080          # DICOMweb/HTTP access port
+HTTPS_PORT=9443         # DICOMweb/HTTPS access port
 DICOM_PORT=4242         # DIMSE port
 
 # Database

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ letsencrypt/
 orthanc-storage/
 postgres-data/
 
+# SSL certificates
+nginx/ssl/
+
 # Logs
 *.log
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,27 @@
 # DICOMweb Stack
 
-A complete DICOMweb implementation with Orthanc and UPS-RS support, all behind a unified nginx proxy. This setup provides a single-command installation with automatic configuration.
+A non-clinical, research only, all in-one DICOMweb implementation with Orthanc and UPS-RS support, all behind a unified nginx proxy. This setup provides a single-command installation with automatic configuration and SSL/TLS support.
 
 ## Features
 
 - **Orthanc**: Full DICOMweb server (QIDO-RS, WADO-RS, STOW-RS) with DIMSE support
-- **pyupsrs**: UPS-RS (Unified Procedure Step) implementation 
+- **pyupsrs**: UPS-RS (Unified Procedure Step) implementation
 - **PostgreSQL**: Database backend for Orthanc
 - **Nginx**: High-performance reverse proxy with unified access point
+- **SSL/TLS Support**: Automatic HTTPS configuration with self-signed certificates for development
 - **One-command setup**: Everything is configured automatically
 
 ## Prerequisites
 
 - Docker and Docker Compose installed
 - 4GB+ RAM available
-- Ports 9080, 4242 available (configurable)
+- Ports 9080, 9443, 4242 available (configurable)
 
 ## Quick Start
 
 1. Clone this repository:
    ```bash
-   git clone https://github.com/yourusername/pyupsrs-dicomweb-stack.git
+   git clone https://github.com/sjswerdloff/pyupsrs-dicomweb-stack.git
    cd pyupsrs-dicomweb-stack
    ```
 
@@ -38,7 +39,8 @@ That's it! The script will:
 
 Once setup is complete:
 
-- **DICOMweb Base URL**: http://localhost:9080/dicom-web
+- **DICOMweb Base URL (HTTP)**: http://localhost:9080/dicom-web
+- **DICOMweb Base URL (HTTPS)**: https://localhost:9443/dicom-web
 - **DIMSE Port**: localhost:4242 (AE Title: ORTHANC)
 - **Orthanc Web UI**: http://localhost:9080/
 
@@ -91,7 +93,11 @@ findscu -P -aec ORTHANC -k QueryRetrieveLevel=STUDY localhost 4242
 ### WebSocket Operations
 
 ```javascript
+// HTTP WebSocket
 const ws = new WebSocket('ws://localhost:9080/dicom-web/ws/subscribers/{subscriber_id}');
+
+// HTTPS WebSocket (WSS)
+const wss = new WebSocket('wss://localhost:9443/dicom-web/ws/subscribers/{subscriber_id}');
 
 ws.onopen = () => {
     console.log('Connected to UPS notifications');
@@ -137,6 +143,7 @@ The `.env.example` file contains available configuration options:
 ```env
 # Ports
 HTTP_PORT=9080          # DICOMweb/HTTP access port
+HTTPS_PORT=9443         # DICOMweb/HTTPS access port
 DICOM_PORT=4242         # DIMSE port
 
 # Database
@@ -144,6 +151,40 @@ POSTGRES_PASSWORD=orthanc  # PostgreSQL password
 ```
 
 To customize, copy `.env.example` to `.env` and edit before running setup.
+
+### SSL/TLS Configuration
+
+The setup automatically generates a self-signed certificate for development use if no certificate is provided. For network use:
+
+1. Place your SSL certificate at `./nginx/ssl/cert.pem`
+2. Place your private key at `./nginx/ssl/key.pem`
+3. Run the setup script
+
+#### Dealing with Self-Signed Certificate Warnings
+
+**Browser Warnings:**
+- Chrome: Click "Advanced" → "Proceed to localhost (unsafe)"
+- Firefox: Click "Advanced" → "Accept the Risk and Continue"
+- Safari: Click "Show Details" → "visit this website"
+
+**Using curl with self-signed certificates:**
+```bash
+# Use -k flag to bypass certificate verification
+curl -k https://localhost:9443/dicom-web/studies
+
+# Or for more verbose output
+curl -kv https://localhost:9443/dicom-web/studies
+```
+
+**Using dicomweb-client with self-signed certificates:**
+```bash
+# Set environment variable to disable SSL verification
+export PYTHONHTTPSVERIFY=0
+dicomweb_client --url https://localhost:9443/dicom-web store instances /path/to/dicom/files/*.dcm
+
+# Or use --insecure flag (if supported by your version)
+dicomweb_client --insecure --url https://localhost:9443/dicom-web store instances /path/to/dicom/files/*.dcm
+```
 
 ### Default Credentials
 
@@ -161,9 +202,9 @@ To use pyupsrs from a GitHub repository instead of PyPI:
    cp pyupsrs/Dockerfile.github pyupsrs/Dockerfile
    ```
 
-2. Edit `pyupsrs/Dockerfile` to set your repository:
+2. Edit `pyupsrs/Dockerfile` to set your repository (change from sjswerdloff to your fork and branch) :
    ```dockerfile
-   ARG GITHUB_REPO="https://github.com/yourusername/pyupsrs.git"
+   ARG GITHUB_REPO="https://github.com/sjswerdloff/pyupsrs.git"
    ARG GITHUB_BRANCH="main"
    ```
 
@@ -177,9 +218,9 @@ To use pyupsrs from a GitHub repository instead of PyPI:
 
 For local development with a cloned pyupsrs repository:
 
-1. Clone pyupsrs locally:
+1. Clone pyupsrs locally (change from sjswerdloff to your fork) :
    ```bash
-   git clone https://github.com/yourusername/pyupsrs.git /path/to/pyupsrs
+   git clone https://github.com/sjswerdloff/pyupsrs.git /path/to/pyupsrs
    ```
 
 2. Use the local Dockerfile:
@@ -195,7 +236,7 @@ For local development with a cloned pyupsrs repository:
        dockerfile: /path/to/dicomweb-stack/pyupsrs/Dockerfile
    ```
 
-4. Rebuild and run:
+4. After making your code changes, Rebuild and run:
    ```bash
    docker-compose build pyupsrs
    docker-compose up -d
@@ -205,11 +246,12 @@ For local development with a cloned pyupsrs repository:
 
 ```
 Client Request → Nginx → http://localhost:9080/dicom-web/*
+                      → https://localhost:9443/dicom-web/* (SSL/TLS)
   ├── /dicom-web/workitems/* → pyupsrs:8000/workitems/*
   ├── /dicom-web/ws/subscribers/* → pyupsrs:8000/ws/subscribers/* (WebSocket)
   └── /dicom-web/* → orthanc:8042/dicom-web/*
 
-DIMSE Request → http://localhost:4242 → orthanc:4242
+DIMSE Request → localhost:4242 → orthanc:4242
 ```
 
 The DICOMweb base URL follows the standard convention where all services (studies, series, instances, workitems) are accessed as paths under the base URL.
@@ -219,6 +261,8 @@ The DICOMweb base URL follows the standard convention where all services (studie
 - UPS-RS returns 404 when no workitems exist (this is correct behavior per DICOM standard)
 - pyupsrs must bind to 0.0.0.0 (not 127.0.0.1) to be accessible from nginx container
 - The nginx configuration handles URL rewriting to strip the `/dicom-web` prefix when forwarding to pyupsrs
+- Self-signed certificates are automatically generated for development use
+- Both HTTP and HTTPS are supported simultaneously for backward compatibility
 
 ## Management Commands
 
@@ -258,7 +302,7 @@ rm -rf postgres-data orthanc-storage
 ### Services won't start
 Check if ports are already in use:
 ```bash
-netstat -tulpn | grep -E '9080|4242'
+netstat -tulpn | grep -E '9080|9443|4242'
 ```
 
 ### Cannot access DICOMweb endpoints
@@ -286,8 +330,10 @@ rm -rf postgres-data orthanc-storage
 
 - `docker-compose-nginx.yml` - Main service definitions
 - `nginx/nginx.conf` - Nginx routing configuration
+- `nginx/nginx-ssl.conf` - Nginx configuration with SSL support
+- `nginx/ssl/` - Directory for SSL certificates (auto-generated if not provided)
 - `.env.example` - Environment variables template
-- `setup-nginx.sh` - Setup script
+- `setup-nginx.sh` - Setup script with automatic SSL certificate generation
 - `pyupsrs/Dockerfile` - Dockerfile for pyupsrs (using PyPI)
 - `pyupsrs/Dockerfile.github` - Alternative Dockerfile for GitHub source
 - `pyupsrs/Dockerfile.local` - Alternative Dockerfile for local development

--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -6,8 +6,10 @@ services:
     restart: unless-stopped
     ports:
       - '${HTTP_PORT:-9080}:80'
+      - '${HTTPS_PORT:-9443}:443'
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/ssl:/etc/nginx/ssl:ro
     networks:
       - dicomweb-network
 

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -46,9 +46,7 @@ http {
         # WebSocket endpoint
         location /dicom-web/ws/subscribers {
             rewrite ^/dicom-web/ws/subscribers(.*)$ /ws/subscribers$1 break;
-            # See https://github.com/socketry/falcon/discussions/167
-            # proxy_pass http://pyupsrs/ws/subscribers/;  # full path required?
-            proxy_pass http://pyupsrs/; #trailing slash required?
+            proxy_pass http://pyupsrs;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
@@ -77,12 +75,12 @@ http {
 
         ssl_certificate /etc/nginx/ssl/cert.pem;
         ssl_certificate_key /etc/nginx/ssl/key.pem;
-
+        
         # Modern SSL configuration
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
         ssl_prefer_server_ciphers off;
-
+        
         # SSL session caching
         ssl_session_cache shared:SSL:10m;
         ssl_session_timeout 10m;
@@ -115,10 +113,6 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Forwarded-Port $server_port;
             proxy_read_timeout 3600s;
             proxy_send_timeout 3600s;
         }

--- a/setup-nginx.sh
+++ b/setup-nginx.sh
@@ -27,6 +27,34 @@ set +a
 # Create necessary directories
 mkdir -p nginx
 
+# SSL Certificate Setup
+echo "🔒 Checking SSL certificates..."
+if [ -f "./nginx/ssl/cert.pem" ] && [ -f "./nginx/ssl/key.pem" ]; then
+    echo "✓ Using existing SSL certificates"
+else
+    echo "No SSL certificates found. Generating self-signed certificate for development..."
+    mkdir -p ./nginx/ssl
+    
+    # Generate self-signed certificate
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout ./nginx/ssl/key.pem \
+        -out ./nginx/ssl/cert.pem \
+        -subj "/C=US/ST=Development/L=Local/O=DICOMweb-Stack/CN=localhost" \
+        2>/dev/null
+    
+    if [ $? -eq 0 ]; then
+        echo "✓ Self-signed certificate generated successfully"
+        echo "  ⚠️  Note: Browsers will show security warnings - this is normal for development"
+    else
+        echo "❌ Failed to generate self-signed certificate"
+        exit 1
+    fi
+fi
+
+# Copy the SSL-enabled nginx configuration
+echo "📄 Configuring nginx with SSL support..."
+cp ./nginx/nginx-ssl.conf ./nginx/nginx.conf
+
 echo "🚀 Starting services..."
 docker-compose -f docker-compose-nginx.yml up -d
 
@@ -34,8 +62,22 @@ echo ""
 echo "✅ Setup complete!"
 echo ""
 echo "🌐 Access your services at:"
-echo "   - DICOMweb Base URL: http://localhost:${HTTP_PORT:-9080}/dicom-web"
+echo "   - DICOMweb Base URL (HTTP): http://localhost:${HTTP_PORT:-9080}/dicom-web"
+echo "   - DICOMweb Base URL (HTTPS): https://localhost:${HTTPS_PORT:-9443}/dicom-web"
 echo "   - Orthanc Web UI: http://localhost:${HTTP_PORT:-9080}/"
+echo "   - DIMSE Port: localhost:${DICOM_PORT:-4242}"
+echo ""
+echo "🔒 SSL Certificate Information:"
+if [ -f "./nginx/ssl/cert.pem" ]; then
+    CERT_INFO=$(openssl x509 -in ./nginx/ssl/cert.pem -subject -issuer -dates -noout 2>/dev/null)
+    if echo "$CERT_INFO" | grep -q "O=DICOMweb-Stack"; then
+        echo "   - Using self-signed certificate (development)"
+        echo "   - Browsers will show security warnings - this is expected"
+        echo "   - Use 'curl -k' to bypass certificate warnings"
+    else
+        echo "   - Using custom SSL certificate"
+    fi
+fi
 echo ""
 echo "🔍 To check service status:"
 echo "   docker-compose -f docker-compose-nginx.yml ps"


### PR DESCRIPTION
## Summary by Sourcery

Provide SSL/TLS support with automatic self-signed certificates, update Nginx and Docker configurations to serve both HTTP and HTTPS (including secure WebSockets), and document the new setup in the README.

New Features:
- Introduce HTTPS support with SSL/TLS in the DICOMweb stack, including secure WebSocket (WSS) endpoints.

Enhancements:
- Configure Nginx to serve both HTTP and HTTPS with appropriate proxy headers (including X-Forwarded-*) and increased body size for DICOM uploads.
- Automate self-signed certificate generation in the setup script and mount SSL artifacts in the Nginx container.
- Expose HTTPS port (9443) via Docker Compose and environment variables while preserving HTTP access.

Build:
- Add HTTPS_PORT to `.env.example` and update Docker Compose to map SSL volumes and ports.

Documentation:
- Update README with SSL/TLS configuration instructions, browser and CLI guidance for self-signed certificates, and examples for HTTPS and secure WebSocket endpoints.

Chores:
- Add a dedicated `nginx-ssl.conf` for SSL-enabled Nginx configuration.